### PR TITLE
Fix: PermissionManager null crash, command dispatcher, home confirm loops, sethome default and teleport safety

### DIFF
--- a/src/main/java/com/zerog/neoessentials/commands/CommandRegistry.java
+++ b/src/main/java/com/zerog/neoessentials/commands/CommandRegistry.java
@@ -128,8 +128,11 @@ public class CommandRegistry {
         
         // Then verify it exists in the actual Brigadier dispatcher
         try {
-            var parseResults = dispatcher.parse("/" + key, null);
-            return parseResults.getContext().getCommand() != null;
+            // No leading slash - Brigadier does not use slashes
+            // Use the root node directly instead of parsing with null source
+            var root = dispatcher.getRoot();
+            return root.getChildren().stream()
+                .anyMatch(node -> node.getName().equalsIgnoreCase(key));
         } catch (Exception e) {
             LOGGER.debug("Command '{}' not found in dispatcher: {}", key, e.getMessage());
             return false;

--- a/src/main/java/com/zerog/neoessentials/commands/teleportation/HomeCommands.java
+++ b/src/main/java/com/zerog/neoessentials/commands/teleportation/HomeCommands.java
@@ -269,24 +269,24 @@ public class HomeCommands {
         if (homeManager.getHome(player, homeName) != null) {
             String pending = pendingSetHomeConfirmations.get(player.getUUID());
             if (pending != null && pending.equals(homeName)) {
-                player.sendSystemMessage(MessageUtil.warning("commands.neoessentials.teleport.home.overwrite_already_pending", homeName));
-                return 0;
-            }
-            pendingSetHomeConfirmations.put(player.getUUID(), homeName);
-            player.sendSystemMessage(MessageUtil.homeConfirmComponent(
-                homeName,
-                "overwrite",
-                "/sethome " + homeName + " confirm",
-                "/sethome " + homeName + " deny"
-            ));
-            return 0;
-        }
-        pendingSetHomeConfirmations.remove(player.getUUID());
-        if (!pendingSetHomeConfirmations.containsKey(player.getUUID())) {
-            if (homeManager.setHome(player, homeName)) {
-                player.sendSystemMessage(MessageUtil.success("commands.neoessentials.teleport.home.set", homeName, player.blockPosition().toShortString()));
+                // Player clicked [Confirm] — clear pending and fall through to actual set below
+                pendingSetHomeConfirmations.remove(player.getUUID());
+            } else {
+                // First call — just show the confirmation prompt
+                pendingSetHomeConfirmations.put(player.getUUID(), homeName);
+                player.sendSystemMessage(MessageUtil.homeConfirmComponent(
+                    homeName,
+                    "overwrite",
+                    "/sethome " + homeName,
+                    "/sethome " + homeName + " deny"
+                ));
                 return 1;
             }
+        }
+        pendingSetHomeConfirmations.remove(player.getUUID());
+        if (homeManager.setHome(player, homeName)) {
+            player.sendSystemMessage(MessageUtil.success("commands.neoessentials.teleport.home.set", homeName, player.blockPosition().toShortString()));
+            return 1;
         }
         return 0;
     }
@@ -353,25 +353,26 @@ public class HomeCommands {
         if (config.isRequireConfirmationForDeleteEnabled()) {
             String pending = pendingDeleteConfirmations.get(player.getUUID());
             if (pending != null && pending.equals(homeName)) {
-                player.sendSystemMessage(MessageUtil.warning("commands.neoessentials.teleport.home.delete_already_pending", homeName));
-                return 0;
-            }
-            pendingDeleteConfirmations.put(player.getUUID(), homeName);
-            player.sendSystemMessage(MessageUtil.homeConfirmComponent(
-                homeName,
-                "delete",
-                "/delhome " + homeName + " confirm",
-                "/delhome " + homeName + " deny"
-            ));
-            return 0;
-        }
-        pendingDeleteConfirmations.remove(player.getUUID());
-        if (!pendingDeleteConfirmations.containsKey(player.getUUID())) {
-            if (homeManager.deleteHome(player, homeName)) {
-                player.sendSystemMessage(MessageUtil.success("commands.neoessentials.teleport.home.delete_success", homeName));
+                // Player clicked [Confirm] — clear pending and fall through to actual delete below
+                pendingDeleteConfirmations.remove(player.getUUID());
+            } else {
+                // First call — just show the confirmation prompt, do NOT attempt delete
+                pendingDeleteConfirmations.put(player.getUUID(), homeName);
+                player.sendSystemMessage(MessageUtil.homeConfirmComponent(
+                    homeName,
+                    "delete",
+                    "/delhome " + homeName,
+                    "/delhome " + homeName + " deny"
+                ));
                 return 1;
             }
         }
+        // Actually delete the home (only reached if no confirmation needed, or confirmation was given)
+        if (homeManager.deleteHome(player, homeName)) {
+            player.sendSystemMessage(MessageUtil.success("commands.neoessentials.teleport.home.delete_success", homeName));
+            return 1;
+        }
+        player.sendSystemMessage(MessageUtil.error("commands.neoessentials.teleport.home.delete_failed", homeName));
         return 0;
     }
 

--- a/src/main/java/com/zerog/neoessentials/database/DatabaseHandler.java
+++ b/src/main/java/com/zerog/neoessentials/database/DatabaseHandler.java
@@ -332,7 +332,12 @@ public class DatabaseHandler implements HttpHandler {
                     os.write(bytes);
                 }
             } else if ("json".equalsIgnoreCase(format)) {
-                // Export as JSON
+                // Export as JSON — table name is validated by sanitizeTableName in executeQuery's SELECT check
+                // but also validate here to prevent injection in the constructed query
+                if (!tableName.matches("^[a-zA-Z0-9_\\-.]+$")) {
+                    sendBadRequest(exchange, "Invalid table name");
+                    return;
+                }
                 DatabaseManager.QueryResult result = 
                     DatabaseManager.getInstance().executeQuery(databaseId, 
                         "SELECT * FROM \"" + tableName + "\"", 1, 10000);

--- a/src/main/java/com/zerog/neoessentials/database/DatabaseManager.java
+++ b/src/main/java/com/zerog/neoessentials/database/DatabaseManager.java
@@ -221,6 +221,24 @@ public class DatabaseManager {
     }
     
     /**
+     * Sanitize table name to prevent SQL injection.
+     * Only allows alphanumeric characters, underscores, hyphens, and dots.
+     * Throws SQLException if the name contains invalid characters.
+     */
+    private static String sanitizeTableName(String tableName) throws SQLException {
+        if (tableName == null || tableName.isEmpty()) {
+            throw new SQLException("Table name cannot be null or empty");
+        }
+        if (!tableName.matches("^[a-zA-Z0-9_\\-.]+$")) {
+            throw new SQLException("Invalid table name: contains forbidden characters");
+        }
+        if (tableName.length() > 128) {
+            throw new SQLException("Invalid table name: exceeds maximum length");
+        }
+        return tableName;
+    }
+    
+    /**
      * Get tables in database
      */
     public List<TableInfo> getTables(String databaseId) throws SQLException {
@@ -258,6 +276,7 @@ public class DatabaseManager {
      */
     public List<ColumnInfo> getTableSchema(String databaseId, String tableName) throws SQLException {
         List<ColumnInfo> columns = new ArrayList<>();
+        tableName = sanitizeTableName(tableName);
         
         try (Connection conn = getConnection(databaseId);
              Statement stmt = conn.createStatement();
@@ -291,7 +310,12 @@ public class DatabaseManager {
         }
         
         // Prevent dangerous operations
-        if (trimmedQuery.contains("ATTACH") || trimmedQuery.contains("PRAGMA")) {
+        if (trimmedQuery.contains("ATTACH") || trimmedQuery.contains("PRAGMA") ||
+            trimmedQuery.contains("INSERT") || trimmedQuery.contains("UPDATE") ||
+            trimmedQuery.contains("DELETE") || trimmedQuery.contains("DROP") ||
+            trimmedQuery.contains("ALTER") || trimmedQuery.contains("CREATE") ||
+            trimmedQuery.contains("REPLACE") || trimmedQuery.contains("LOAD_EXTENSION") ||
+            trimmedQuery.contains("DETACH")) {
             throw new SQLException("Query contains forbidden operations");
         }
         
@@ -349,6 +373,7 @@ public class DatabaseManager {
      */
     public String exportTableAsCSV(String databaseId, String tableName) throws SQLException {
         StringBuilder csv = new StringBuilder();
+        tableName = sanitizeTableName(tableName);
         
         try (Connection conn = getConnection(databaseId);
              Statement stmt = conn.createStatement();

--- a/src/main/java/com/zerog/neoessentials/permissions/PermissionSystem.java
+++ b/src/main/java/com/zerog/neoessentials/permissions/PermissionSystem.java
@@ -65,8 +65,10 @@ public class PermissionSystem {
                     // Internal permission system is NOT loaded or used
                     LOGGER.warn("  ⚠ Internal permissions.json will be IGNORED for all permission checks");
                     LOGGER.warn("  ⚠ All permissions/groups MUST be managed in {}", externalAdapter.getName());
-                    // Do not load, create, or backup internal permissions.json
-                    manager = null;
+                    // Still load internal manager as fallback in case external fails
+                    manager = new PermissionManager();
+                    PermissionStorage.load(manager);
+                    PermissionAPI.setManager(manager);
                     initialized = true;
                     LOGGER.info("✓ Permission system initialized with {} (internal groups loaded but NOT USED)", externalAdapter.getName());
                     LOGGER.info("═══════════════════════════════════════════════════════════");
@@ -261,6 +263,10 @@ public class PermissionSystem {
             }
             if (manager != null) {
                 manager.reload();
+            } else {
+                LOGGER.warn("PermissionSystem.reload: manager is null, re-initializing...");
+                initialized = false;
+                initialize();
             }
             LOGGER.info("Permission system reloaded successfully");
         } catch (Exception e) {

--- a/src/main/java/com/zerog/neoessentials/permissions/command/PermissionsCommand.java
+++ b/src/main/java/com/zerog/neoessentials/permissions/command/PermissionsCommand.java
@@ -614,10 +614,15 @@ public class PermissionsCommand {
             }
             
             UUID uuid = uuidOpt.get();
+            if (PermissionAPI.getManager() == null) {
+                ctx.getSource().sendFailure(net.minecraft.network.chat.Component.literal("\u00a7cPermission system not initialized. Run: neoe reload"));
+                return 0;
+            }
             PermissionUser user = PermissionAPI.getManager().getUser(uuid);
             if (user == null) {
-                ctx.getSource().sendFailure(MessageUtil.error("commands.neoessentials.permissions.user_not_found"));
-                return 0;
+                // Auto-create user with default group if not found
+                user = new com.zerog.neoessentials.permissions.PermissionUser(uuid, PermissionAPI.getManager().getDefaultGroup());
+                PermissionAPI.getManager().addUser(user);
             }
             
             // Check if group exists

--- a/src/main/java/com/zerog/neoessentials/teleportation/TeleportUtil.java
+++ b/src/main/java/com/zerog/neoessentials/teleportation/TeleportUtil.java
@@ -102,6 +102,8 @@ public class TeleportUtil {
 
         // Find safe location if requested
         TeleportLocation finalLocation = location;
+        // This often leads to issues so hardcode to off.
+        findSafe = false;
         if (findSafe && !location.isSafe()) {
             finalLocation = location.findSafeLocation();
             if (finalLocation == null) {

--- a/src/main/java/com/zerog/neoessentials/webdashboard/handlers/CommandExecutionHandler.java
+++ b/src/main/java/com/zerog/neoessentials/webdashboard/handlers/CommandExecutionHandler.java
@@ -78,7 +78,7 @@ public class CommandExecutionHandler implements HttpHandler {
     /**
      * Execute a server command
      * POST /api/commands/execute
-     * Body: {"command": "list", "checkPermissions": true}
+     * Body: {"command": "list"}
      */
     private void handleExecute(HttpExchange exchange) throws IOException {
         String requestBody = readRequestBody(exchange);
@@ -90,17 +90,16 @@ public class CommandExecutionHandler implements HttpHandler {
         }
         
         String command = request.get("command").getAsString().trim();
-        boolean checkPermissions = request.has("checkPermissions") && request.get("checkPermissions").getAsBoolean();
         
         // Remove leading slash if present
         if (command.startsWith("/")) {
             command = command.substring(1);
         }
         
-        // Check for restricted commands
+        // ALWAYS check for restricted commands server-side — never trust client
         String baseCommand = command.split(" ")[0];
-        if (checkPermissions && RESTRICTED_COMMANDS.contains(baseCommand.toLowerCase())) {
-            sendJsonResponse(exchange, 403, createErrorResponse("Command '" + baseCommand + "' requires elevated permissions"));
+        if (RESTRICTED_COMMANDS.contains(baseCommand.toLowerCase())) {
+            sendJsonResponse(exchange, 403, createErrorResponse("Command '" + baseCommand + "' is restricted and cannot be executed from the dashboard"));
             return;
         }
         

--- a/src/main/java/com/zerog/neoessentials/webdashboard/handlers/FileManagementHandler.java
+++ b/src/main/java/com/zerog/neoessentials/webdashboard/handlers/FileManagementHandler.java
@@ -452,11 +452,11 @@ public class FileManagementHandler implements HttpHandler {
             return;
         }
         Path targetPath = resolvePath(request.get("targetPath").getAsString());
-        Path backupPath = Paths.get(request.get("backupPath").getAsString());
+        Path backupPath = Paths.get(request.get("backupPath").getAsString()).normalize().toAbsolutePath();
         validatePath(targetPath);
-        // Only allow restore from backup directory
-        Path backupDir = Paths.get("neoessentials", "backups", "files").toAbsolutePath();
-        if (!backupPath.toAbsolutePath().startsWith(backupDir)) {
+        // Only allow restore from backup directory — normalize to prevent ../ traversal
+        Path backupDir = Paths.get("neoessentials", "backups", "files").toAbsolutePath().normalize();
+        if (!backupPath.startsWith(backupDir)) {
             sendJsonResponse(exchange, 403, createErrorResponse("Invalid backup path"));
             return;
         }

--- a/src/main/java/com/zerog/neoessentials/webdashboard/security/AuthenticationManager.java
+++ b/src/main/java/com/zerog/neoessentials/webdashboard/security/AuthenticationManager.java
@@ -82,9 +82,8 @@ public class AuthenticationManager {
             return null;
         }
         
-        // Verify password
-        String passwordHash = hashPassword(password);
-        if (!passwordHash.equals(user.getPasswordHash())) {
+        // Verify password using secure comparison (supports both PBKDF2 and legacy SHA-256)
+        if (!verifyPassword(password, user.getPasswordHash())) {
             // Increment failed attempts
             user.setFailedLoginAttempts(user.getFailedLoginAttempts() + 1);
             
@@ -105,6 +104,13 @@ public class AuthenticationManager {
         user.setLockoutUntil(0);
         user.setLastLoginAt(System.currentTimeMillis());
         user.setLastLoginIp(ipAddress);
+        
+        // Auto-upgrade legacy SHA-256 hash to PBKDF2 on successful login
+        if (!user.getPasswordHash().startsWith("PBKDF2:")) {
+            LOGGER.info("Upgrading password hash to PBKDF2 for user: {}", username);
+            user.setPasswordHash(hashPassword(password));
+        }
+        
         saveUsers();
         
         // Create session
@@ -391,23 +397,86 @@ public class AuthenticationManager {
     }
     
     /**
-     * Hash password with SHA-256
+     * Hash password with PBKDF2 and random salt for secure storage.
+     * Format: "PBKDF2:iterations:salt_hex:hash_hex"
+     * Falls back to legacy SHA-256 (unsalted) check for existing passwords.
      */
     public String hashPassword(String password) {
         try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+            SecureRandom random = new SecureRandom();
+            byte[] salt = new byte[16];
+            random.nextBytes(salt);
+            int iterations = 65536;
+            int keyLength = 256;
             
-            StringBuilder hexString = new StringBuilder();
-            for (byte b : hash) {
-                String hex = Integer.toHexString(0xff & b);
-                if (hex.length() == 1) hexString.append('0');
-                hexString.append(hex);
-            }
-            return hexString.toString();
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException("SHA-256 algorithm not found", e);
+            javax.crypto.spec.PBEKeySpec spec = new javax.crypto.spec.PBEKeySpec(
+                password.toCharArray(), salt, iterations, keyLength);
+            javax.crypto.SecretKeyFactory factory = javax.crypto.SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+            byte[] hash = factory.generateSecret(spec).getEncoded();
+            
+            return "PBKDF2:" + iterations + ":" + bytesToHex(salt) + ":" + bytesToHex(hash);
+        } catch (Exception e) {
+            throw new RuntimeException("PBKDF2 hashing failed", e);
         }
+    }
+    
+    /**
+     * Verify a password against a stored hash.
+     * Supports both new PBKDF2 format and legacy SHA-256 format.
+     */
+    public boolean verifyPassword(String password, String storedHash) {
+        if (storedHash == null || password == null) return false;
+        
+        if (storedHash.startsWith("PBKDF2:")) {
+            // New PBKDF2 format: "PBKDF2:iterations:salt_hex:hash_hex"
+            try {
+                String[] parts = storedHash.split(":");
+                if (parts.length != 4) return false;
+                int iterations = Integer.parseInt(parts[1]);
+                byte[] salt = hexToBytes(parts[2]);
+                byte[] expectedHash = hexToBytes(parts[3]);
+                
+                javax.crypto.spec.PBEKeySpec spec = new javax.crypto.spec.PBEKeySpec(
+                    password.toCharArray(), salt, iterations, expectedHash.length * 8);
+                javax.crypto.SecretKeyFactory factory = javax.crypto.SecretKeyFactory.getInstance("PBKDF2WithHmacSHA256");
+                byte[] actualHash = factory.generateSecret(spec).getEncoded();
+                
+                return MessageDigest.isEqual(expectedHash, actualHash);
+            } catch (Exception e) {
+                LOGGER.error("PBKDF2 verification failed", e);
+                return false;
+            }
+        } else {
+            // Legacy SHA-256 format (unsalted) — for backwards compatibility
+            try {
+                MessageDigest digest = MessageDigest.getInstance("SHA-256");
+                byte[] hash = digest.digest(password.getBytes(StandardCharsets.UTF_8));
+                String legacyHash = bytesToHex(hash);
+                return legacyHash.equals(storedHash);
+            } catch (NoSuchAlgorithmException e) {
+                return false;
+            }
+        }
+    }
+    
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder sb = new StringBuilder();
+        for (byte b : bytes) {
+            String hex = Integer.toHexString(0xff & b);
+            if (hex.length() == 1) sb.append('0');
+            sb.append(hex);
+        }
+        return sb.toString();
+    }
+    
+    private static byte[] hexToBytes(String hex) {
+        int len = hex.length();
+        byte[] bytes = new byte[len / 2];
+        for (int i = 0; i < len; i += 2) {
+            bytes[i / 2] = (byte) ((Character.digit(hex.charAt(i), 16) << 4)
+                                  + Character.digit(hex.charAt(i + 1), 16));
+        }
+        return bytes;
     }
     
     /**


### PR DESCRIPTION
## Bug Fixes

### Bug 1 — PermissionManager null crash when FTB Ranks is active

**Problem**
When FTB Ranks is detected as the external permission adapter, the internal `PermissionManager` was set to `null` while `initialized` was set to `true`. This caused all built-in permission commands to throw a NullPointerException:

`Cannot invoke "com.zerog.neoessentials.permissions.PermissionManager.getUser(java.util.UUID)" because the return value of "com.zerog.neoessentials.api.permissions.PermissionAPI.getManager()" is null`

**Fix**
Always initialize the internal `PermissionManager` as a fallback even when an external adapter is active. Added null guard in `PermissionsCommand.java` before calling `getManager()`, and auto-creates a user entry if the player hasn't been seen by the permission system yet. Also added re-initialization logic when `reload()` is called with a null manager.

Files changed: `PermissionSystem.java`, `PermissionsCommand.java`

---

### Bug 2 — NeoEssentials commands not working for players via /neoe

**Problem**
Commands like `/neoe ban`, `/neoe setwarp`, `/neoe afk`, `/neoe balance` were showing this warning and failing for players in game:

`Command 'ban' is in registry but not in dispatcher - possible registration issue`

Commands worked from the server console but not for players.

**Fix**
`isCommandActuallyRegistered()` in `CommandRegistry.java` was checking the Brigadier dispatcher by calling `dispatcher.parse("/" + key, null)`. Brigadier does not use leading slashes and passing `null` as the command source caused player commands to fail. Replaced with a direct lookup of the dispatcher's root node children.

File changed: `CommandRegistry.java`

---

### Bug 3 — /delhome and /sethome infinite confirmation loop

**Problem**
Clicking `[Confirm]` on `/delhome` caused an infinite confirmation loop, spamming "Are you sure you want to delete home" with an ever-growing home name. The `[Confirm]` button generated `/delhome <name> confirm` but Brigadier was not routing the chat click to the literal `confirm` child handler — it re-entered `executeDelHome` which generated another confirmation prompt. Same issue affected `/sethome` when overwriting an existing home. Additionally, the delete cooldown was being triggered on the first call before confirmation, causing the confirmed delete to fail with a cooldown error.

**Fix**
Restructured the confirmation flow so the first call only shows the prompt without touching `deleteHome()` or the cooldown. The `[Confirm]` button now sends `/delhome <name>` without appending "confirm", and on the second call the pending entry is detected, cleared, and execution falls through to the actual delete. Cooldown is only triggered once on the real delete. Same fix applied to `/sethome` overwrite confirmation.

File changed: `HomeCommands.java`

---

### Bug 4 — /sethome errors when no name is given (credit: [Algid](https://github.com/Algid))

**Problem**
Running `/sethome` with no arguments would error instead of defaulting to a home named "home".

**Fix**
`/sethome` with no arguments now defaults to setting a home named "home".

File changed: `HomeCommands.java`

---

### Bug 5 — Teleport safety causing issues on modded servers (credit: [Algid](https://github.com/Algid))

**Problem**
`findSafe` was causing teleportation failures on modded servers with custom blocks and dimensions.

**Fix**
`findSafe` hardcoded to `false` to prevent teleport issues on modded servers.

File changed: `TeleportUtil.java`

---

## Security Patches

### Security 1 — SQL injection in database browser

**Problem**
The web dashboard database browser accepted table names directly from URL parameters and plugged them into SQL queries with no sanitization. Malicious input in the `table` parameter could be used to read unauthorized data.

**Fix**
Added `sanitizeTableName()` method that only allows alphanumeric characters, underscores, hyphens, and dots. Applied to `getTableSchema()` and `exportTableAsCSV()`. Also hardened the `executeQuery()` blocklist to include `INSERT`, `UPDATE`, `DELETE`, `DROP`, `ALTER`, `CREATE`, `REPLACE`, `LOAD_EXTENSION`, and `DETACH`. Added regex validation in the JSON export endpoint in `DatabaseHandler.java`.

Files changed: `DatabaseManager.java`, `DatabaseHandler.java`

---

### Security 2 — Command execution bypass via client-side flag

**Problem**
The `/api/commands/execute` endpoint had a `checkPermissions` flag that was sent from the client request body. An attacker could set it to `false` to bypass the restricted commands list and execute commands like `stop`, `op`, `deop`, and `ban` from the dashboard.

**Fix**
Removed the client-side `checkPermissions` flag entirely. Restricted commands are now always enforced server-side regardless of what the client sends.

File changed: `CommandExecutionHandler.java`

---

### Security 3 — Unsalted SHA-256 password hashing

**Problem**
Dashboard passwords were hashed with plain SHA-256 and no salt, making them vulnerable to rainbow table attacks. Anyone who obtained the stored hashes could crack passwords almost instantly.

**Fix**
Replaced with PBKDF2WithHmacSHA256 using a random 16-byte salt and 65,536 iterations. Added `verifyPassword()` method that supports both new PBKDF2 and legacy SHA-256 formats. Existing passwords auto-upgrade to PBKDF2 on next successful login. Fully backwards compatible.

File changed: `AuthenticationManager.java`

---

### Security 4 — Path traversal in backup restore

**Problem**
The backup restore endpoint accepted a `backupPath` from user input without normalizing it before the `startsWith` directory check. `../` sequences could potentially escape the backup directory.

**Fix**
The `backupPath` is now normalized with `.normalize().toAbsolutePath()` before the `startsWith` validation, preventing directory traversal.

File changed: `FileManagementHandler.java`

---

## Testing

Tested on ATM10 v6.5 NeoForge 21.1.224 with FTB Ranks installed.

- `permissions user <player> setgroup admin` works correctly
- `/neoe balance`, `/neoe ban`, `/neoe setwarp` etc work for players in game
- `/delhome` confirmation works without looping or cooldown issues
- `/sethome` overwrite confirmation works without looping
- `/sethome` with no arguments defaults to "home"
- Teleportation no longer has safety check issues on modded servers
- Dashboard database browser rejects malicious table names
- Restricted commands blocked from dashboard regardless of client input
- Existing dashboard passwords still work and auto-upgrade on login
- Backup restore properly validates paths