### PR TITLE
fix(dashboard): fix nav blocking href links and JSON parsing in permissions API

### DIFF
--- a/src/main/resources/webdashboard/dashboard.js
+++ b/src/main/resources/webdashboard/dashboard.js
@@ -124,9 +124,13 @@ function showDashboard() {
     // Update username display
     const username = localStorage.getItem('username');
     const usernameDisplay = document.getElementById('usernameDisplay');
-    if (usernameDisplay && username) {
-        usernameDisplay.textContent = username;
-    }
+    if (usernameDisplay && username) { usernameDisplay.textContent = username; }
+    const userNameEl = document.getElementById('userName');
+    if (userNameEl && username) { userNameEl.textContent = username; }
+
+
+
+
     
     // Show admin controls if user is admin
     const isAdmin = localStorage.getItem('isAdmin') === 'true';
@@ -270,9 +274,9 @@ function setupEventListeners() {
     const navItems = document.querySelectorAll('.nav-item');
     navItems.forEach(item => {
         item.addEventListener('click', (e) => {
-            e.preventDefault();
             const page = item.getAttribute('data-page');
             if (page) {
+                e.preventDefault();
                 switchPage(page);
             }
         });
@@ -445,6 +449,13 @@ function setupNavigation() {
     
     navItems.forEach(item => {
         item.addEventListener('click', (e) => {
+            const pageName = item.getAttribute('data-page');
+            // Items without data-page (e.g. permissions.html, admin.html) navigate normally
+            if (!pageName) {
+                navItems.forEach(nav => nav.classList.remove('active'));
+                item.classList.add('active');
+                return;
+            }
             e.preventDefault();
             
             // Remove active class from all items
@@ -453,8 +464,7 @@ function setupNavigation() {
             // Add active class to clicked item
             item.classList.add('active');
             
-            // Get page name
-            const pageName = item.getAttribute('data-page');
+            // Get page name (already fetched above)
             const pageTitle = item.querySelector('.nav-text').textContent;
             
             // Update page title

--- a/src/main/resources/webdashboard/permissions.js
+++ b/src/main/resources/webdashboard/permissions.js
@@ -10,6 +10,13 @@ const PermissionSystem = {
 };
 
 // Initialize permission system when page loads
+// Helper: fetch authenticated JSON (fetchWithAuth returns raw Response; this parses it)
+async function fetchJSON(url, options) {
+    const response = await fetchWithAuth(url, options);
+    if (!response.ok) throw new Error('HTTP ' + response.status);
+    return response.json();
+}
+
 async function initPermissionSystem() {
     console.log('Initializing permission system...');
 
@@ -100,7 +107,7 @@ async function loadTabData(tabName) {
 // Load permission system status
 async function loadPermissionSystemStatus() {
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/system/status`);
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/system/status`);
         PermissionSystem.systemStatus = response;
         PermissionSystem.usingExternal = response.usingExternal;
 
@@ -148,7 +155,7 @@ async function loadPermissionSystemStatus() {
 // Load permission overview
 async function loadPermissionOverview() {
     try {
-        const overview = await fetchWithAuth(`${API_BASE_URL}/permissions/overview`);
+        const overview = await fetchJSON(`${API_BASE_URL}/permissions/overview`);
 
         // Update stats
         document.getElementById('totalGroupsStat').textContent = overview.totalGroups || 0;
@@ -195,7 +202,7 @@ async function loadAllGroups() {
     }
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/groups`);
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/groups`);
         PermissionSystem.groups = response.groups || [];
 
         renderGroupsTable(PermissionSystem.groups);
@@ -262,7 +269,7 @@ function renderGroupsTable(groups) {
 // Load all users
 async function loadAllUsers() {
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/users`);
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/users`);
         PermissionSystem.users = response.users || [];
 
         renderUsersTable(PermissionSystem.users);
@@ -325,7 +332,7 @@ function renderUsersTable(users) {
 // Load all available permissions
 async function loadAllPermissions() {
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/permissions/all`);
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/permissions/all`);
         PermissionSystem.permissions = response.categories || [];
 
         renderPermissionsCategories(PermissionSystem.permissions);
@@ -446,7 +453,7 @@ async function submitCreateGroup() {
     }
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/group/create`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/group/create`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ name, prefix, suffix, weight, isDefault })
@@ -514,7 +521,7 @@ window.submitEditGroup = async function(groupName) {
     const weight = parseInt(document.getElementById('editGroupWeight').value);
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/group/${groupName}/update`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/group/${groupName}/update`, {
             method: 'PUT',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ prefix, suffix, weight })
@@ -536,7 +543,7 @@ window.submitEditGroup = async function(groupName) {
 // View group permissions
 async function viewGroupPermissions(groupName) {
     try {
-        const group = await fetchWithAuth(`${API_BASE_URL}/permissions/group/${groupName}`);
+        const group = await fetchJSON(`${API_BASE_URL}/permissions/group/${groupName}`);
 
         const modalHTML = `
             <div class="modal" id="groupPermModal" style="display: flex;">
@@ -590,7 +597,7 @@ window.addGroupPermission = async function(groupName) {
     if (!permission) return;
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/group/${groupName}/permission/add`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/group/${groupName}/permission/add`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ permission })
@@ -612,7 +619,7 @@ window.removeGroupPermission = async function(groupName, permission) {
     if (!confirm(`Remove permission "${permission}" from group "${groupName}"?`)) return;
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/group/${groupName}/permission/remove/${encodeURIComponent(permission)}`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/group/${groupName}/permission/remove/${encodeURIComponent(permission)}`, {
             method: 'DELETE'
         });
 
@@ -633,7 +640,7 @@ async function deleteGroup(groupName) {
     if (!confirm(`Are you sure you want to delete group "${groupName}"?`)) return;
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/group/${groupName}`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/group/${groupName}`, {
             method: 'DELETE'
         });
 
@@ -652,7 +659,7 @@ async function deleteGroup(groupName) {
 // Edit user permissions
 async function editUserPermissions(username) {
     try {
-        const user = await fetchWithAuth(`${API_BASE_URL}/permissions/user/${username}`);
+        const user = await fetchJSON(`${API_BASE_URL}/permissions/user/${username}`);
 
         const modalHTML = `
             <div class="modal" id="userPermModal" style="display: flex;">
@@ -711,7 +718,7 @@ window.addUserPermission = async function(username) {
     if (!permission) return;
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/user/${username}/permission/add`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/user/${username}/permission/add`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ permission })
@@ -733,7 +740,7 @@ window.removeUserPermission = async function(username, permission) {
     if (!confirm(`Remove permission "${permission}" from user "${username}"?`)) return;
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/user/${username}/permission/remove/${encodeURIComponent(permission)}`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/user/${username}/permission/remove/${encodeURIComponent(permission)}`, {
             method: 'DELETE'
         });
 
@@ -789,7 +796,7 @@ window.submitChangeGroup = async function(username) {
     const group = document.getElementById('newUserGroup').value;
 
     try {
-        const response = await fetchWithAuth(`${API_BASE_URL}/permissions/user/${username}/group/set`, {
+        const response = await fetchJSON(`${API_BASE_URL}/permissions/user/${username}/group/set`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ group })


### PR DESCRIPTION
## Summary

Two bugs that together prevent the Permissions and Admin pages from being accessible or functional.

**Bug 1 — `setupNavigation()` blocks all navigation unconditionally**

The nav click handler calls `e.preventDefault()` on every nav item click, including items that have an `href` to a separate page (like `permissions.html` and `admin.html`) but no `data-page` attribute. Those links never navigate:

```js
// Before — preventDefault called unconditionally
item.addEventListener('click', (e) => {
    e.preventDefault();
    const pageName = item.getAttribute('data-page');
    ...

// After — only preventDefault for SPA page items
item.addEventListener('click', (e) => {
    const pageName = item.getAttribute('data-page');
    if (!pageName) { /* update active state and return */ return; }
    e.preventDefault();
    ...
```

**Bug 2 — `permissions.js` treats `fetchWithAuth` return as parsed JSON**

`fetchWithAuth` returns the raw `Response` object (correctly — `dashboard.js` uses `response.ok`, `response.json()` etc.). However, all 15+ calls in `permissions.js` treat the return value as already-parsed JSON, accessing `.totalGroups`, `.groups`, `.usingExternal` etc. directly — all of which are `undefined` on a Response object.

Fix: inject a `fetchJSON` helper in `permissions.js` that calls `fetchWithAuth` then `.json()`, and use it for all permissions API calls without changing `fetchWithAuth` itself (preserving dashboard.js behaviour):

```js
async function fetchJSON(url, options) {
    const response = await fetchWithAuth(url, options);
    if (!response.ok) throw new Error('HTTP ' + response.status);
    return response.json();
}
```

## Test plan
- [ ] Click "Permissions" in sidebar — URL changes to `permissions.html` (was: no navigation)
- [ ] Click "Admin Controls" in sidebar — URL changes to `admin.html`
- [ ] On `permissions.html`, groups/users/stats load correctly (was: always "Loading...")
- [ ] On `permissions.html`, group management actions (create/delete/edit) work correctly