### PR TITLE
fix(dashboard): preserve admin flags in Minecraft auth and validate paths

### DIFF
--- a/src/main/resources/webdashboard/dashboard.js
+++ b/src/main/resources/webdashboard/dashboard.js
@@ -93,6 +93,7 @@ async function checkAuthentication() {
             const data = await response.json();
             localStorage.setItem('username', data.username);
             localStorage.setItem('isAdmin', data.isAdmin);
+            if (data.isAdmin === true) { localStorage.setItem('role', 'ADMIN'); }
             localStorage.setItem('authType', data.authType);
             showDashboard();
         } else {
@@ -403,9 +404,9 @@ async function handleLogin() {
                 localStorage.setItem('isAdmin', data.user.role === 'ADMIN' || data.user.isAdmin || false);
                 localStorage.setItem('role', data.user.role || 'VIEWER');
             } else {
-                localStorage.setItem('username', username.trim());
-                localStorage.setItem('isAdmin', false);
-                localStorage.setItem('role', 'VIEWER');
+                localStorage.setItem('username', data.username || username.trim());
+                localStorage.setItem('isAdmin', data.isAdmin === true);
+                localStorage.setItem('role', data.isAdmin === true ? 'ADMIN' : 'VIEWER');
             }
 
             // Show dashboard


### PR DESCRIPTION
## Summary

Two related auth state bugs in `dashboard.js`:

**Bug 1 — Login else-branch hardcodes `isAdmin: false`**

When the Minecraft player auth path returns a response without a `data.user` object, the else-branch ignores `data.isAdmin` (which is `true` for admins) and stores `false`:

```js
// Before
localStorage.setItem('isAdmin', false);
localStorage.setItem('role', 'VIEWER');

// After
localStorage.setItem('isAdmin', data.isAdmin === true);
localStorage.setItem('role', data.isAdmin === true ? 'ADMIN' : 'VIEWER');
```

**Bug 2 — Validate path never sets `role`**

The validate handler sets `isAdmin` but not `role`. Admin-only UI elements check `role === 'ADMIN'`, so admins see a read-only dashboard until they trigger a fresh login:

```js
// After validate response, also set role
if (data.isAdmin === true) { localStorage.setItem('role', 'ADMIN'); }
```

## Test plan
- [ ] Log in via Minecraft player auth as a player with `neoessentials.dashboard.admin` permission — admin controls visible immediately without refresh
- [ ] Log in, navigate away, return — admin controls still visible (validate path)
- [ ] Log in as non-admin — dashboard shows read-only correctly